### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that connects to the Tesla Fleet API, allowing you to control your Tesla vehicle using Claude and other AI assistants that support MCP.
 
+<a href="https://glama.ai/mcp/servers/t0ako8h64j">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/t0ako8h64j/badge" alt="Tesla Server MCP server" />
+</a>
+
 ## Features
 
 - **Wake up vehicles**: Wake up your Tesla from sleep mode


### PR DESCRIPTION
This PR adds a badge for the [Tesla MCP Server](https://glama.ai/mcp/servers/t0ako8h64j) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/t0ako8h64j">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/t0ako8h64j/badge" alt="Tesla Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.